### PR TITLE
simplify source freshness

### DIFF
--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -4,6 +4,10 @@ sources:
   - name: ecom
     schema: jaffle_shop_raw
     description: E-commerce data for the Jaffle Shop
+    freshness:
+      warn_after:
+        count: 10
+        period: day
     tables:
       - name: raw_customers
         description: One record per person who has purchased one or more items

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -6,25 +6,17 @@ sources:
     description: E-commerce data for the Jaffle Shop
     freshness:
       warn_after:
-        count: 10
-        period: day
+        count: 24
+        period: hour
     tables:
       - name: raw_customers
         description: One record per person who has purchased one or more items
       - name: raw_orders
         description: One record per order (consisting of one or more order items)
-        freshness:
-          warn_after:
-            count: 24
-            period: hour
         loaded_at_field: ordered_at
       - name: raw_items
         description: Items included in an order
       - name: raw_stores
-        freshness:
-          warn_after:
-            count: 24
-            period: hour
         loaded_at_field: opened_at
       - name: raw_products
         description: One record per SKU for items sold in stores


### PR DESCRIPTION
I want to get source freshness on all sources so that we see it in explorer! this should be sufficient, and the best part is we don't need a `loaded_at_field` anymore with 1.7+!