### PR TITLE
disable seeds in prod

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,6 +23,7 @@ vars:
 
 seeds:
   jaffle_shop:
+    +enabled: "{{ target.name != 'prod' }}"
     +schema: jaffle_shop_raw
 
 models:


### PR DESCRIPTION
i think our best path for using this project in cloud to hide the seeds we're using as a "data loader" is to just disable them in prod -- this means they won't be in the manifest in prod, and therefore won't show up in the explorer lineage