### PR TITLE
Update date truncate var to be BQ compatible

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,7 @@ clean-targets:
   - "dbt_packages"
 
 vars:
-  truncate_timespan_to: "{{ current_timestamp() }}"
+  truncate_timespan_to: "cast({{ dbt_date.now() }} as datetime)"
   "dbt_date:time_zone": "America/Los_Angeles"
 
 seeds:


### PR DESCRIPTION
Now that we've set up a BQ connection, we need an explicit cast here as BQ will not make inferences when comparing a datetime and a timestamp.