### PR TITLE
Add saved queries and exports for SL

### DIFF
--- a/models/marts/customers.yml
+++ b/models/marts/customers.yml
@@ -55,6 +55,9 @@ semantic_models:
         type_params:
           time_granularity: day
     measures:
+      - name: customers
+        description: Count of unique customers
+        agg: count_distinct
       - name: count_lifetime_orders
         description: Total count of orders per customer.
         agg: sum
@@ -64,3 +67,40 @@ semantic_models:
       - name: lifetime_spend
         agg: sum
         description: Gross customer lifetime spend inclusive of taxes.
+
+metrics:
+  - name: lifetime_spend_pretax
+    description: Customer's lifetime spend before tax
+    label: LTV Pre-tax
+    type: simple
+    type_params:
+      measure: lifetime_spend_pretax
+  - name: count_lifetime_orders
+    description: Count of lifetime orders
+    label: Count Lifetime Orders
+    type: simple
+    type_params:
+      measure: count_lifetime_orders
+  - name: average_order_value
+    description: LTV pre-tax / number of orders
+    label: Average Order Value
+    type: derived
+    type_params:
+      metrics:
+        - count_lifetime_orders
+        - lifetime_spend_pretax
+      expr: lifetime_spend_pretax / count_lifetime_orders
+
+saved_queries:
+  - name: customer_order_metrics
+    query_params:
+      metrics:
+        - count_lifetime_orders
+        - lifetime_spend_pretax
+        - average_order_value
+      group_by:
+        - Entity('customer')
+    exports:
+      - name: customer_order_metrics
+        config:
+          export_as: table

--- a/models/marts/order_items.yml
+++ b/models/marts/order_items.yml
@@ -111,8 +111,14 @@ metrics:
     type: simple
     type_params:
       measure: food_revenue
+  - name: drink_revenue
+    description: The revenue from drinks in each order
+    label: Drink Revenue
+    type: simple
+    type_params:
+      measure: drink_revenue
 
-  #Ratio Metrics
+  # Ratio Metrics
   - name: food_revenue_pct
     description: The % of order revenue from food.
     label: Food Revenue %
@@ -120,8 +126,15 @@ metrics:
     type_params:
       numerator: food_revenue
       denominator: revenue
+  - name: drink_revenue_pct
+    description: The % of order revenue from drinks.
+    label: Drink Revenue %
+    type: ratio
+    type_params:
+      numerator: drink_revenue
+      denominator: revenue
 
-  #Derived Metrics
+  # Derived Metrics
   - name: revenue_growth_mom
     description: "Percentage growth of revenue compared to 1 month ago. Excluded tax"
     type: derived
@@ -152,3 +165,17 @@ metrics:
     type: cumulative
     type_params:
       measure: revenue
+
+saved_queries:
+  - name: revenue_metrics
+    query_params:
+      metrics:
+        - revenue
+        - food_revenue
+        - drink_revenue
+      group_by:
+        - TimeDimension('metric_time', 'day')
+    exports:
+      - name: revenue_metrics
+        config:
+          export_as: table

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -30,7 +30,6 @@ order_items_summary as (
 
 ),
 
-
 compute_booleans as (
 
     select
@@ -49,6 +48,19 @@ compute_booleans as (
         order_items_summary
         on orders.order_id = order_items_summary.order_id
 
+),
+
+add_customer_order_count as (
+
+    select
+        *,
+        row_number() over (
+            partition by customer_id
+            order by ordered_at asc
+        ) as customer_order_number
+
+    from compute_booleans
+
 )
 
-select * from compute_booleans
+select * from add_customer_order_count

--- a/models/marts/orders.yml
+++ b/models/marts/orders.yml
@@ -104,6 +104,8 @@ semantic_models:
         type: categorical
       - name: is_drink_order
         type: categorical
+      - name: customer_order_number
+        type: categorical
     measures:
       - name: order_total
         description: The total amount for each order including taxes.
@@ -125,6 +127,14 @@ metrics:
     label: Order Total
     type_params:
       measure: order_total
+  - name: new_customer_orders
+    description: New customer's first order count
+    label: New Customers
+    type: simple
+    type_params:
+      measure: order_count
+    filter: |
+      {{ Dimension('order_id__customer_order_number') }} = 1
   - name: large_orders
     description: "Count of orders with order total over 20."
     type: simple
@@ -155,3 +165,19 @@ metrics:
       measure: order_count
     filter: |
       {{ Dimension('order_id__is_drink_order') }} = true
+
+saved_queries:
+  - name: order_metrics
+    query_params:
+      metrics:
+        - orders
+        - new_customer_orders
+        - order_total
+        - food_orders
+        - drink_orders
+      group_by:
+        - TimeDimension('metric_time', 'day')
+    exports:
+      - name: order_metrics
+        config:
+          export_as: table


### PR DESCRIPTION
The Semantic Layer has an awesome feature to allow the construction and materialization of queries based on your metrics. We've added those to the Jaffle Shop and expanded the SL implementation a bit.