### PR TITLE
[Fix] Postgres-specific `cents_to_dollars` macro

### DIFF
--- a/macros/cents_to_dollars.sql
+++ b/macros/cents_to_dollars.sql
@@ -8,6 +8,10 @@
     ({{ column_name }} / 100)::numeric(16, 2)
 {%- endmacro %}
 
+{% macro postgres__cents_to_dollars(column_name) -%}
+    ({{ column_name }}::numeric(16, 2) / 100)
+{%- endmacro %}
+
 {% macro bigquery__cents_to_dollars(column_name) %}
     round(cast(({{ column_name }} / 100) as numeric), 2)
 {% endmacro %}


### PR DESCRIPTION
Postgres needs a little bit of special sauce to properly pad zeros to 2 decimals in the `cents_to_dollars` macro.