### PR TITLE
Fabric adapter doesnt work with default cents_to_dollars macro

### DIFF
--- a/macros/cents_to_dollars.sql
+++ b/macros/cents_to_dollars.sql
@@ -15,3 +15,7 @@
 {% macro bigquery__cents_to_dollars(column_name) %}
     round(cast(({{ column_name }} / 100) as numeric), 2)
 {% endmacro %}
+
+{% macro fabric__cents_to_dollars(column_name) %}
+    cast({{ column_name }} / 100 as numeric(16,2))
+{% endmacro %}


### PR DESCRIPTION
Using dbt-fabric adapter, trying to run dbt build fails with the following error:

('42000', "[42000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Incorrect syntax near '::'. (102) (SQLMoreResults)")

Adding a fabric specific macro (code supplied in this PR) for the cents_to_dollars macro fixes this.