### PR TITLE
Demo that config setting for unit tests are broken

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,3 +34,11 @@ models:
       +materialized: view
     marts:
       +materialized: table
+
+unit_tests:
+  jaffle_shop:
+    +expected_sql: "This also is identified as unused!"
+    marts:
+      order_items:
+        test_supply_costs_sum_correctly:
+          expected_sql: "Oh no, identified as unused!"


### PR DESCRIPTION
# Demo
I've added two config paths in the `dbt_project.yaml` for unit tests. Both _are_ valid. However, if you run `dbt parse` you will see the following:
```
(venv) quigleymalcolm@Quigley-Malcolm jaffle-shop % dbt parse                                                                 
22:56:16  Running with dbt=1.8.2
22:56:16  Registered adapter: postgres=1.8.1
22:56:16  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 3 unused configuration paths:
- seeds.jaffle_shop
- unit_tests.jaffle_shop
- unit_tests.jaffle_shop.marts.order_items.test_supply_costs_sum_correctly
22:56:16  Performance info: /Users/quigleymalcolm/Developer/dbt-labs/jaffle-shop/target/perf_info.json
```

###Note
The only lines here that are incorrect are the two beginning `- unit_tests.`