### PR TITLE
fix(metrics): food+drink revenue use 'is true' not =1

### DIFF
--- a/models/marts/order_items.yml
+++ b/models/marts/order_items.yml
@@ -75,11 +75,11 @@ semantic_models:
       - name: food_revenue
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
-        expr: case when is_food_item = 1 then product_price else 0 end
+        expr: case when is_food_item is true then product_price else 0 end
       - name: drink_revenue
         description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
         agg: sum
-        expr: case when is_drink_item = 1 then product_price else 0 end
+        expr: case when is_drink_item is true then product_price else 0 end
       - name: median_revenue
         description: The median revenue generated for each order item.
         agg: median


### PR DESCRIPTION
Snowflake doesn't mind if you use =0/1 for booleans, but BigQuery, our friend BQ? He does not like it. This makes him happier and is more correct/resilient across dialects.