### PR TITLE
Update .sqlfluff to use dbt-cloud templater by default

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,5 +1,5 @@
 [sqlfluff]
-templater = dbt
+templater = dbt-cloud
 dialect = snowflake
 runaway_limit = 10
 max_line_length = 80


### PR DESCRIPTION
Since this is a dbt cloud focused repo, we should provide the dbt-cloud sqlfluff templater. 