### PR TITLE
docs: fix csv filename in S3 bucket URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ To load the data from S3, consult the [dbt Documentation's Quickstart Guides](ht
 
 - `raw_customers`: `s3://jaffle-shop-raw/raw_customers.csv`
 - `raw_orders`: `s3://jaffle-shop-raw/raw_orders.csv`
-- `raw_order_items`: `s3://jaffle-shop-raw/raw_order_items.csv`
+- `raw_items`: `s3://jaffle-shop-raw/raw_items.csv`
 - `raw_products`: `s3://jaffle-shop-raw/raw_products.csv`
 - `raw_supplies`: `s3://jaffle-shop-raw/raw_supplies.csv`
 - `raw_stores`: `s3://jaffle-shop-raw/raw_stores.csv`


### PR DESCRIPTION
## Description
This PR fixes a documentation error in the README where the S3 bucket URI for the items table is incorrectly listed as `raw_order_items.csv` when the actual file in the bucket is `raw_items.csv`.

## Problem
Users following the quickstart guide encounter errors when trying to load `raw_order_items.csv` as this file doesn't exist in the S3 bucket.

## Solution
Updated the README to reference the correct filename `raw_items.csv` which is the actual file present in the bucket.

## Verification
Verified by attempting to download both files:
- 's3://jaffle-shop-raw/raw_order_items.csv' - fails with 403 error
- 's3://jaffle-shop-raw/raw_items.csv' - downloads successfully
