### PR TITLE
Migrate dbt-date to GoDataDriven

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,8 +1,8 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.1.1
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: 0.10.0
   - git: https://github.com/dbt-labs/dbt-audit-helper.git
-    revision: 74072850a5bccd90235576d67530c98e3b7437f4
-sha1_hash: da0d5b1d5a48f6504805f6b1d5a0b2f9f233f34c
+    revision: b8f3a3348ce0ff8afc3aa4b9ade2123b00772473
+sha1_hash: f2a73967505955af30d18f70489a423fd47cdf79

--- a/packages.yml
+++ b/packages.yml
@@ -1,7 +1,7 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.1.1
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: 0.10.0
   - git: "https://github.com/dbt-labs/dbt-audit-helper.git"
     revision: main


### PR DESCRIPTION
Calogica's [dbt-date](https://github.com/calogica/dbt-date) package is no longer supported. Instead, GoDataDriven's [dbt-date](https://github.com/metaplane/dbt-date) package is now featured on the [dbt Package Hub](https://hub.getdbt.com/godatadriven/dbt_date/latest/). This PR migrates the dependency in this repo.