### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: requirements-txt-fixer
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.4
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format


### PR DESCRIPTION
Update pre-commit hooks to their current upstream sources and versions.

- Bump `pre-commit-hooks` to v6.0.0
- Migrate `ruff` hooks from `charliermarsh` to `astral-sh` (upstream move)
  - Switch to `ruff-check` (current hook name)

This is a maintenance-only change, i.e. no rule changes and no impact on runtime behaviour.