### PR TITLE
feat: add clickhouse__cents_to_dollars override

### DIFF
--- a/macros/cents_to_dollars.sql
+++ b/macros/cents_to_dollars.sql
@@ -19,3 +19,20 @@
 {% macro fabric__cents_to_dollars(column_name) %}
     cast({{ column_name }} / 100 as numeric(16,2))
 {% endmacro %}
+
+{#
+  ClickHouse: Int64 / Int64 promotes to Float64 before the ::numeric cast.
+  e.g. 1908 / 100 = 19.0799999... in Float64, which truncates to 19.07 instead of 19.08.
+  Fix: use intDiv + modulo to stay in integer arithmetic, then build the decimal string.
+  See: https://github.com/ClickHouse/jaffle-shop-clickhouse
+#}
+{% macro clickhouse__cents_to_dollars(column_name) %}
+    toDecimal64(
+        concat(
+            toString(intDiv({{ column_name }}, 100)),
+            '.',
+            leftPad(toString({{ column_name }} % 100), 2, '0')
+        ),
+        2
+    )
+{% endmacro %}


### PR DESCRIPTION
## Summary

Adds a `clickhouse__cents_to_dollars` dispatch override to fix incorrect results when running the jaffle_shop project against ClickHouse.

## Root cause

ClickHouse promotes `Int64 / Int64` to `Float64` before applying a `::numeric` cast. This means:

```sql
-- default__cents_to_dollars generates:
(1908 / 100)::numeric(16, 2)

-- ClickHouse evaluates as:
CAST(Float64(19.0799999...), 'numeric(16, 2)')  →  19.07  ❌
```

`1908 / 100` is `19.079999...` in IEEE 754 double precision, which truncates to `19.07` instead of `19.08`. Postgres and DuckDB avoid this because they either stay in integer arithmetic or cast before dividing — ClickHouse uniquely hits this path.

This causes `dbt_utils_expression_is_true` tests on `order_total`, `subtotal`, and `tax_paid` columns to fail with `-0.01` discrepancies.

## Fix

Uses `intDiv` + modulo to stay entirely in integer arithmetic:

```sql
toDecimal64(
    concat(
        toString(intDiv(col, 100)),           -- 1908 ÷ 100 = 19
        '.',
        leftPad(toString(col % 100), 2, '0')  -- 1908 % 100 = 08
    ),
    2
)  →  toDecimal64('19.08', 2)  =  19.08  ✅
```

This is the same approach used in [`ClickHouse/jaffle-shop-clickhouse`](https://github.com/ClickHouse/jaffle-shop-clickhouse/blob/main/macros/cents_to_dollars.sql), the official ClickHouse fork of this project.

## Testing

Confirmed with ClickHouse 24.3 — all three previously-failing `expression_is_true` tests (`order_total`, `stg_orders`, `customers` lifetime spend) now pass.