### PR TITLE
feat: add metricflow_time_spine.yml to register time spine with MetricFlow

### DIFF
--- a/models/marts/metricflow_time_spine.yml
+++ b/models/marts/metricflow_time_spine.yml
@@ -1,0 +1,7 @@
+models:
+  - name: metricflow_time_spine
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        granularity: day


### PR DESCRIPTION
## Summary

`models/marts/metricflow_time_spine.sql` exists but has no companion `.yml` to register it with MetricFlow. Without the `.yml`, the time spine is not recognized as a MetricFlow time spine model, so any metrics that depend on it won't resolve correctly.

This PR adds the missing `.yml`:

```yaml
models:
  - name: metricflow_time_spine
    time_spine:
      standard_granularity_column: date_day
    columns:
      - name: date_day
        granularity: day
```

This is already present in the [`ClickHouse/jaffle-shop-clickhouse`](https://github.com/ClickHouse/jaffle-shop-clickhouse/blob/main/models/marts/metricflow_time_spine.yml) fork and is adapter-agnostic — it belongs upstream.