### PR TITLE
Feature/add customer ltv model

### DIFF
--- a/models/marts/customer_lifetime_value.sql
+++ b/models/marts/customer_lifetime_value.sql
@@ -3,39 +3,42 @@
     schema='marts'
 ) }}
 
-with customer_orders as (
-    select
-        customer_id,
-        min(order_date) as first_order_date,
-        max(order_date) as most_recent_order_date,
-        count(order_id) as total_orders,
-        sum(amount) as lifetime_spend
-    from {{ ref('stg_orders') }}
-    group by customer_id
+-- Customer Lifetime Value Mart Model
+-- Purpose: Enriches customer data with lifetime metrics and segmentation
+
+with customers as (
+    select * from {{ ref('stg_customers') }}
 ),
 
-customer_metrics as (
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customer_orders_summary as (
     select
-        c.customer_id,
-        c.first_name,
-        c.last_name,
-        co.first_order_date,
-        co.most_recent_order_date,
-        datediff(day, co.first_order_date, current_date) as customer_age_days,
-        co.total_orders,
-        co.lifetime_spend,
-        round(co.lifetime_spend / nullif(co.total_orders, 0), 2) as avg_order_value
-    from {{ ref('stg_customers') }} c
-    left join customer_orders co 
-        on c.customer_id = co.customer_id
+        customer_id,
+        count(*) as lifetime_order_count,
+        min(ordered_at) as first_order_at,
+        max(ordered_at) as last_order_at,
+        sum(order_total) as lifetime_spend
+    from orders
+    group by 1
 )
 
 select
-    *,
+    c.*,
+    cos.lifetime_order_count,
+    cos.first_order_at,
+    cos.last_order_at,
+    cos.lifetime_spend,
+    datediff('day', cos.first_order_at, current_date) as days_as_customer,
+    
     case 
-        when lifetime_spend >= 1000 then 'High Value'
-        when lifetime_spend >= 500 then 'Medium Value'
+        when cos.lifetime_spend >= 1000 then 'High Value'
+        when cos.lifetime_spend >= 500 then 'Medium Value'
         else 'Low Value'
     end as customer_segment
-from customer_metrics
-order by lifetime_spend desc
+
+from customers c
+left join customer_orders_summary cos 
+    on c.customer_id = cos.customer_id

--- a/models/marts/customer_lifetime_value.sql
+++ b/models/marts/customer_lifetime_value.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='table',
+    schema='marts'
+) }}
+
+with customer_orders as (
+    select
+        customer_id,
+        min(order_date) as first_order_date,
+        max(order_date) as most_recent_order_date,
+        count(order_id) as total_orders,
+        sum(amount) as lifetime_spend
+    from {{ ref('stg_orders') }}
+    group by customer_id
+),
+
+customer_metrics as (
+    select
+        c.customer_id,
+        c.first_name,
+        c.last_name,
+        co.first_order_date,
+        co.most_recent_order_date,
+        datediff(day, co.first_order_date, current_date) as customer_age_days,
+        co.total_orders,
+        co.lifetime_spend,
+        round(co.lifetime_spend / nullif(co.total_orders, 0), 2) as avg_order_value
+    from {{ ref('stg_customers') }} c
+    left join customer_orders co 
+        on c.customer_id = co.customer_id
+)
+
+select
+    *,
+    case 
+        when lifetime_spend >= 1000 then 'High Value'
+        when lifetime_spend >= 500 then 'Medium Value'
+        else 'Low Value'
+    end as customer_segment
+from customer_metrics
+order by lifetime_spend desc

--- a/models/marts/customers.yml
+++ b/models/marts/customers.yml
@@ -6,7 +6,7 @@ models:
           expression: "lifetime_spend_pretax + lifetime_tax_paid = lifetime_spend"
     columns:
       - name: customer_id
-        description: The unique key of the orders mart.
+        description: The unique key of the customers mart.
         data_tests:
           - not_null
           - unique


### PR DESCRIPTION
## What this PR does

- Adds a new mart model `customer_lifetime_value.sql`
- Enriches customer data with lifetime metrics (lifetime spend, order count, first/last order date)
- Adds customer segmentation (High / Medium / Low Value)
- Calculates days as customer

## Why this is useful

This model helps answer important business questions such as:
- Who are our high-value customers?
- How long have customers been with us?
- Which customers should be prioritized for retention campaigns?

## Technical Details

- Materialized as a table in the `marts` schema
- References `stg_customers` and `stg_orders`
- Follows the existing project style and naming conventions

## How to test

```bash
dbt run --select customer_lifetime_value