### PR TITLE
Update packages.yml with new dbt-date version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -2,6 +2,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.3
   - package: godatadriven/dbt_date
-    version: 0.17.1
+    version: 0.19.0
   - git: "https://github.com/dbt-labs/dbt-audit-helper.git"
     revision: main


### PR DESCRIPTION
Updating dbt-date version as it's now compatible with ClickHouse. https://github.com/godatadriven/dbt-date/releases/tag/0.19.0

This remove one more change needed in the ClickHouse's jaffle-shop fork https://github.com/ClickHouse/jaffle-shop-clickhouse so now it's a bit closer to be removed :D 