### PR TITLE
[codex] Make jaffle shop Fusion compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ profiles.yml
 
 .ruff_cache
 __pycache__
+dbt_internal_packages/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -15,8 +15,6 @@ test-paths: ["data-tests"]
 seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
-
-target-path: "target"
 clean-targets:
   - "target"
   - "dbt_packages"
@@ -26,7 +24,7 @@ vars:
 
 seeds:
   jaffle_shop:
-    +schema: raw
+    +schema: "{{ var('raw_schema', 'raw') }}"
     jaffle-data:
       +enabled: "{{ var('load_source_data', false) }}"
 
@@ -36,3 +34,5 @@ models:
       +materialized: view
     marts:
       +materialized: table
+flags:
+  require_generic_test_arguments_property: true

--- a/models/marts/customers.yml
+++ b/models/marts/customers.yml
@@ -1,23 +1,35 @@
 models:
   - name: customers
-    description: Customer overview data mart, offering key details for each unique customer. One row per customer.
+    description: "Customer overview data mart, offering key details for each unique customer. One row per customer. Customer grain mart.\n"
     data_tests:
       - dbt_utils.expression_is_true:
-          expression: "lifetime_spend_pretax + lifetime_tax_paid = lifetime_spend"
+          arguments:
+            expression: "lifetime_spend_pretax + lifetime_tax_paid = lifetime_spend"
     columns:
       - name: customer_id
         description: The unique key of the orders mart.
         data_tests:
           - not_null
           - unique
+        entity:
+          type: primary
+          name: customer
       - name: customer_name
         description: Customers' full name.
+        dimension:
+          type: categorical
       - name: count_lifetime_orders
         description: Total number of orders a customer has ever placed.
       - name: first_ordered_at
         description: The timestamp when a customer placed their first order.
+        dimension:
+          type: time
+        granularity: day
       - name: last_ordered_at
         description: The timestamp of a customer's most recent order.
+        dimension:
+          type: time
+        granularity: day
       - name: lifetime_spend_pretax
         description: The sum of all the pre-tax subtotals of every order a customer has placed.
       - name: lifetime_tax_paid
@@ -28,70 +40,45 @@ models:
         description: Options are 'new' or 'returning', indicating if a customer has ordered more than once or has only placed their first order to date.
         data_tests:
           - accepted_values:
-              values: ["new", "returning"]
+              arguments:
+                values: ["new", "returning"]
 
-semantic_models:
-  - name: customers
-    defaults:
-      agg_time_dimension: first_ordered_at
-    description: |
-      Customer grain mart.
-    model: ref('customers')
-    entities:
-      - name: customer
-        expr: customer_id
-        type: primary
-    dimensions:
-      - name: customer_name
-        type: categorical
-      - name: customer_type
-        type: categorical
-      - name: first_ordered_at
-        type: time
-        type_params:
-          time_granularity: day
-      - name: last_ordered_at
-        type: time
-        type_params:
-          time_granularity: day
-    measures:
+        dimension:
+          type: categorical
+    semantic_model:
+      enabled: true
+    agg_time_dimension: first_ordered_at
+    metrics:
+      - name: lifetime_spend_pretax
+        description: Customer's lifetime spend before tax
+        label: LTV Pre-tax
+        type: simple
+        agg: sum
+      - name: count_lifetime_orders
+        description: Count of lifetime orders
+        label: Count Lifetime Orders
+        type: simple
+        agg: sum
       - name: customers
         description: Count of unique customers
         agg: count_distinct
         expr: customer_id
-      - name: count_lifetime_orders
-        description: Total count of orders per customer.
-        agg: sum
-      - name: lifetime_spend_pretax
-        description: Customer lifetime spend before taxes.
-        agg: sum
+        type: simple
+        hidden: true
       - name: lifetime_spend
         agg: sum
         description: Gross customer lifetime spend inclusive of taxes.
 
-metrics:
-  - name: lifetime_spend_pretax
-    description: Customer's lifetime spend before tax
-    label: LTV Pre-tax
-    type: simple
-    type_params:
-      measure: lifetime_spend_pretax
-  - name: count_lifetime_orders
-    description: Count of lifetime orders
-    label: Count Lifetime Orders
-    type: simple
-    type_params:
-      measure: count_lifetime_orders
-  - name: average_order_value
-    description: LTV pre-tax / number of orders
-    label: Average Order Value
-    type: derived
-    type_params:
-      metrics:
-        - count_lifetime_orders
-        - lifetime_spend_pretax
-      expr: lifetime_spend_pretax / count_lifetime_orders
-
+        type: simple
+        hidden: true
+      - name: average_order_value
+        description: LTV pre-tax / number of orders
+        label: Average Order Value
+        type: derived
+        expr: lifetime_spend_pretax / count_lifetime_orders
+        input_metrics:
+          - name: count_lifetime_orders
+          - name: lifetime_spend_pretax
 saved_queries:
   - name: customer_order_metrics
     query_params:

--- a/models/marts/locations.yml
+++ b/models/marts/locations.yml
@@ -1,24 +1,26 @@
-semantic_models:
+models:
   - name: locations
+    semantic_model:
+      enabled: true
     description: |
       Location dimension table. The grain of the table is one row per location.
-    model: ref('locations')
-    defaults:
-      agg_time_dimension: opened_date
-    entities:
-      - name: location
-        type: primary
-        expr: location_id
-    dimensions:
+    agg_time_dimension: opened_date
+    columns:
+      - name: location_id
+        entity:
+          type: primary
+          name: location
       - name: location_name
-        type: categorical
+        dimension:
+          type: categorical
       - name: opened_date
-        expr: opened_date
-        type: time
-        type_params:
-          time_granularity: day
-    measures:
+        dimension:
+          type: time
+        granularity: day
+    metrics:
       - name: average_tax_rate
         description: Average tax rate.
         expr: tax_rate
         agg: average
+        type: simple
+        hidden: true

--- a/models/marts/order_items.yml
+++ b/models/marts/order_items.yml
@@ -5,12 +5,96 @@ models:
         data_tests:
           - not_null
           - unique
+        entity:
+          type: primary
+          name: order_item
       - name: order_id
         data_tests:
           - relationships:
-              to: ref('orders')
-              field: order_id
-
+              arguments:
+                to: ref('orders')
+                field: order_id
+        entity:
+          type: foreign
+      - name: product_id
+        entity:
+          type: foreign
+          name: product
+      - name: ordered_at
+        dimension:
+          type: time
+        granularity: day
+      - name: is_food_item
+        dimension:
+          type: categorical
+      - name: is_drink_item
+        dimension:
+          type: categorical
+    semantic_model:
+      enabled: true
+      name: order_items
+    description: |
+      Items contatined in each order. The grain of the table is one row per order item.
+    agg_time_dimension: ordered_at
+    metrics:
+      - name: revenue
+        description: Sum of the product revenue for each order item. Excludes tax.
+        type: simple
+        label: Revenue
+        agg: sum
+        expr: product_price
+      - name: median_revenue
+        description: The median revenue for each order item. Excludes tax.
+        type: simple
+        label: Median Revenue
+        agg: median
+        expr: product_price
+      - name: food_revenue
+        description: The revenue from food in each order
+        label: Food Revenue
+        type: simple
+        agg: sum
+        expr: case when is_food_item then product_price else 0 end
+      - name: drink_revenue
+        description: The revenue from drinks in each order
+        label: Drink Revenue
+        type: simple
+        agg: sum
+        expr: case when is_drink_item then product_price else 0 end
+      - name: food_revenue_pct
+        description: The % of order revenue from food.
+        label: Food Revenue %
+        type: ratio
+        numerator: food_revenue
+        denominator: revenue
+      - name: drink_revenue_pct
+        description: The % of order revenue from drinks.
+        label: Drink Revenue %
+        type: ratio
+        numerator: drink_revenue
+        denominator: revenue
+      - name: revenue_growth_mom
+        description: "Percentage growth of revenue compared to 1 month ago. Excluded tax"
+        type: derived
+        label: Revenue Growth % M/M
+        expr: (current_revenue - revenue_prev_month)*100/revenue_prev_month
+        input_metrics:
+          - name: revenue
+            alias: current_revenue
+          - name: revenue
+            offset_window: 1 month
+            alias: revenue_prev_month
+      - name: revenue_1
+        description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
+        agg: sum
+        expr: product_price
+        type: simple
+        hidden: true
+      - name: cumulative_revenue
+        description: The cumulative revenue for all orders.
+        label: Cumulative Revenue (All Time)
+        type: cumulative
+        input_metric: revenue_1
 unit_tests:
   - name: test_supply_costs_sum_correctly
     description: "Test that the counts of drinks and food orders convert to booleans properly."
@@ -18,154 +102,41 @@ unit_tests:
     given:
       - input: ref('stg_supplies')
         rows:
-          - { product_id: 1, supply_cost: 4.50 }
-          - { product_id: 2, supply_cost: 3.50 }
-          - { product_id: 2, supply_cost: 5.00 }
+          - {product_id: 1, supply_cost: 4.50}
+          - {product_id: 2, supply_cost: 3.50}
+          - {product_id: 2, supply_cost: 5.00}
       - input: ref('stg_products')
         rows:
-          - { product_id: 1 }
-          - { product_id: 2 }
+          - {product_id: 1}
+          - {product_id: 2}
       - input: ref('stg_order_items')
         rows:
-          - { order_id: 1, product_id: 1 }
-          - { order_id: 2, product_id: 2 }
-          - { order_id: 2, product_id: 2 }
+          - {order_id: 1, product_id: 1}
+          - {order_id: 2, product_id: 2}
+          - {order_id: 2, product_id: 2}
       - input: ref('stg_orders')
         rows:
-          - { order_id: 1 }
-          - { order_id: 2 }
+          - {order_id: 1}
+          - {order_id: 2}
     expect:
       rows:
-        - { order_id: 1, product_id: 1, supply_cost: 4.50 }
-        - { order_id: 2, product_id: 2, supply_cost: 8.50 }
-        - { order_id: 2, product_id: 2, supply_cost: 8.50 }
-
-semantic_models:
-  - name: order_item
-    defaults:
-      agg_time_dimension: ordered_at
-    description: |
-      Items contatined in each order. The grain of the table is one row per order item.
-    model: ref('order_items')
-    entities:
-      - name: order_item
-        type: primary
-        expr: order_item_id
-      - name: order_id
-        type: foreign
-        expr: order_id
-      - name: product
-        type: foreign
-        expr: product_id
-    dimensions:
-      - name: ordered_at
-        expr: ordered_at
-        type: time
-        type_params:
-          time_granularity: day
-      - name: is_food_item
-        type: categorical
-      - name: is_drink_item
-        type: categorical
-    measures:
-      - name: revenue
-        description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
-        agg: sum
-        expr: product_price
-      - name: food_revenue
-        description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
-        agg: sum
-        expr: case when is_food_item then product_price else 0 end
-      - name: drink_revenue
-        description: The revenue generated for each order item. Revenue is calculated as a sum of revenue associated with each product in an order.
-        agg: sum
-        expr: case when is_drink_item then product_price else 0 end
-      - name: median_revenue
-        description: The median revenue generated for each order item.
-        agg: median
-        expr: product_price
+        - {order_id: 1, product_id: 1, supply_cost: 4.50}
+        - {order_id: 2, product_id: 2, supply_cost: 8.50}
+        - {order_id: 2, product_id: 2, supply_cost: 8.50}
 
 metrics:
   # Simple metrics
-  - name: revenue
-    description: Sum of the product revenue for each order item. Excludes tax.
-    type: simple
-    label: Revenue
-    type_params:
-      measure: revenue
-  - name: order_cost
-    description: Sum of cost for each order item.
-    label: Order Cost
-    type: simple
-    type_params:
-      measure: order_cost
-  - name: median_revenue
-    description: The median revenue for each order item. Excludes tax.
-    type: simple
-    label: Median Revenue
-    type_params:
-      measure: median_revenue
-  - name: food_revenue
-    description: The revenue from food in each order
-    label: Food Revenue
-    type: simple
-    type_params:
-      measure: food_revenue
-  - name: drink_revenue
-    description: The revenue from drinks in each order
-    label: Drink Revenue
-    type: simple
-    type_params:
-      measure: drink_revenue
-
-  # Ratio Metrics
-  - name: food_revenue_pct
-    description: The % of order revenue from food.
-    label: Food Revenue %
-    type: ratio
-    type_params:
-      numerator: food_revenue
-      denominator: revenue
-  - name: drink_revenue_pct
-    description: The % of order revenue from drinks.
-    label: Drink Revenue %
-    type: ratio
-    type_params:
-      numerator: drink_revenue
-      denominator: revenue
-
-  # Derived Metrics
-  - name: revenue_growth_mom
-    description: "Percentage growth of revenue compared to 1 month ago. Excluded tax"
-    type: derived
-    label: Revenue Growth % M/M
-    type_params:
-      expr: (current_revenue - revenue_prev_month)*100/revenue_prev_month
-      metrics:
-        - name: revenue
-          alias: current_revenue
-        - name: revenue
-          offset_window: 1 month
-          alias: revenue_prev_month
   - name: order_gross_profit
     description: Gross profit from each order.
     type: derived
     label: Order Gross Profit
-    type_params:
-      expr: revenue - cost
-      metrics:
-        - name: revenue
-        - name: order_cost
-          alias: cost
+    expr: revenue - cost
+    input_metrics:
+      - name: revenue
+      - name: order_cost
+        alias: cost
 
   #Cumulative Metrics
-  - name: cumulative_revenue
-    description: The cumulative revenue for all orders.
-    label: Cumulative Revenue (All Time)
-    type: cumulative
-    type_params:
-      measure: revenue
-
 saved_queries:
   - name: revenue_metrics
     query_params:

--- a/models/marts/orders.yml
+++ b/models/marts/orders.yml
@@ -1,34 +1,117 @@
 models:
   - name: orders
-    description: Order overview data mart, offering key details for each order inlcluding if it's a customer's first order and a food vs. drink item breakdown. One row per order.
+    description: "Order overview data mart, offering key details for each order inlcluding if it's a customer's first order and a food vs. drink item breakdown. One row per order. Order fact table. This table is at the order grain with one row per order.\n"
     data_tests:
       - dbt_utils.expression_is_true:
-          expression: "order_items_subtotal = subtotal"
+          arguments:
+            expression: "order_items_subtotal = subtotal"
       - dbt_utils.expression_is_true:
-          expression: "order_total = subtotal + tax_paid"
+          arguments:
+            expression: "order_total = subtotal + tax_paid"
     columns:
       - name: order_id
         description: The unique key of the orders mart.
         data_tests:
           - not_null
           - unique
+        entity:
+          type: primary
       - name: customer_id
         description: The foreign key relating to the customer who placed the order.
         data_tests:
           - relationships:
-              to: ref('stg_customers')
-              field: customer_id
+              arguments:
+                to: ref('stg_customers')
+                field: customer_id
+        entity:
+          type: foreign
+          name: customer
       - name: order_total
         description: The total amount of the order in USD including tax.
+        dimension:
+          type: categorical
+          name: order_total_dim
       - name: ordered_at
         description: The timestamp the order was placed at.
+        dimension:
+          type: time
+        granularity: day
       - name: order_cost
         description: The sum of supply expenses to fulfill the order.
       - name: is_food_order
         description: A boolean indicating if this order included any food items.
+        dimension:
+          type: categorical
       - name: is_drink_order
         description: A boolean indicating if this order included any drink items.
 
+        dimension:
+          type: categorical
+      - name: location_id
+        entity:
+          type: foreign
+          name: location
+      - name: customer_order_number
+        dimension:
+          type: categorical
+    semantic_model:
+      enabled: true
+    agg_time_dimension: ordered_at
+    metrics:
+      - name: order_cost
+        description: Sum of cost for each order item.
+        label: Order Cost
+        type: simple
+        agg: sum
+      - name: order_total
+        description: Sum of total order amonunt. Includes tax + revenue.
+        type: simple
+        label: Order Total
+        agg: sum
+      - name: new_customer_orders
+        description: New customer's first order count
+        label: New Customers
+        type: simple
+        filter: |
+          {{ Dimension('order_id__customer_order_number') }} = 1
+        agg: sum
+        expr: 1
+      - name: large_orders
+        description: "Count of orders with order total over 20."
+        type: simple
+        label: Large Orders
+        filter: |
+          {{ Dimension('order_id__order_total_dim') }} >= 20
+        agg: sum
+        expr: 1
+      - name: orders
+        description: Count of orders.
+        label: Orders
+        type: simple
+        agg: sum
+        expr: 1
+      - name: food_orders
+        description: Count of orders that contain food order items
+        label: Food Orders
+        type: simple
+        filter: |
+          {{ Dimension('order_id__is_food_order') }} = true
+        agg: sum
+        expr: 1
+      - name: drink_orders
+        description: Count of orders that contain drink order items
+        label: Drink Orders
+        type: simple
+        filter: |
+          {{ Dimension('order_id__is_drink_order') }} = true
+
+        agg: sum
+        expr: 1
+      - name: tax_paid
+        description: The total tax paid on each order.
+        agg: sum
+        type: simple
+        hidden: true
 unit_tests:
   - name: test_order_items_compute_to_bools_correctly
     description: "Test that the counts of drinks and food orders convert to booleans properly."
@@ -36,135 +119,17 @@ unit_tests:
     given:
       - input: ref('order_items')
         rows:
-          - {
-              order_id: 1,
-              order_item_id: 1,
-              is_drink_item: false,
-              is_food_item: true,
-            }
-          - {
-              order_id: 1,
-              order_item_id: 2,
-              is_drink_item: true,
-              is_food_item: false,
-            }
-          - {
-              order_id: 2,
-              order_item_id: 3,
-              is_drink_item: false,
-              is_food_item: true,
-            }
+          - {order_id: 1, order_item_id: 1, is_drink_item: false, is_food_item: true}
+          - {order_id: 1, order_item_id: 2, is_drink_item: true, is_food_item: false}
+          - {order_id: 2, order_item_id: 3, is_drink_item: false, is_food_item: true}
       - input: ref('stg_orders')
         rows:
-          - { order_id: 1 }
-          - { order_id: 2 }
+          - {order_id: 1}
+          - {order_id: 2}
     expect:
       rows:
-        - {
-            order_id: 1,
-            count_food_items: 1,
-            count_drink_items: 1,
-            is_drink_order: true,
-            is_food_order: true,
-          }
-        - {
-            order_id: 2,
-            count_food_items: 1,
-            count_drink_items: 0,
-            is_drink_order: false,
-            is_food_order: true,
-          }
-
-semantic_models:
-  - name: orders
-    defaults:
-      agg_time_dimension: ordered_at
-    description: |
-      Order fact table. This table is at the order grain with one row per order.
-    model: ref('orders')
-    entities:
-      - name: order_id
-        type: primary
-      - name: location
-        type: foreign
-        expr: location_id
-      - name: customer
-        type: foreign
-        expr: customer_id
-    dimensions:
-      - name: ordered_at
-        expr: ordered_at
-        type: time
-        type_params:
-          time_granularity: day
-      - name: order_total_dim
-        type: categorical
-        expr: order_total
-      - name: is_food_order
-        type: categorical
-      - name: is_drink_order
-        type: categorical
-      - name: customer_order_number
-        type: categorical
-    measures:
-      - name: order_total
-        description: The total amount for each order including taxes.
-        agg: sum
-      - name: order_count
-        expr: 1
-        agg: sum
-      - name: tax_paid
-        description: The total tax paid on each order.
-        agg: sum
-      - name: order_cost
-        description: The cost for each order item. Cost is calculated as a sum of the supply cost for each order item.
-        agg: sum
-
-metrics:
-  - name: order_total
-    description: Sum of total order amonunt. Includes tax + revenue.
-    type: simple
-    label: Order Total
-    type_params:
-      measure: order_total
-  - name: new_customer_orders
-    description: New customer's first order count
-    label: New Customers
-    type: simple
-    type_params:
-      measure: order_count
-    filter: |
-      {{ Dimension('order_id__customer_order_number') }} = 1
-  - name: large_orders
-    description: "Count of orders with order total over 20."
-    type: simple
-    label: Large Orders
-    type_params:
-      measure: order_count
-    filter: |
-      {{ Dimension('order_id__order_total_dim') }} >= 20
-  - name: orders
-    description: Count of orders.
-    label: Orders
-    type: simple
-    type_params:
-      measure: order_count
-  - name: food_orders
-    description: Count of orders that contain food order items
-    label: Food Orders
-    type: simple
-    type_params:
-      measure: order_count
-    filter: |
-      {{ Dimension('order_id__is_food_order') }} = true
-  - name: drink_orders
-    description: Count of orders that contain drink order items
-    label: Drink Orders
-    type: simple
-    type_params:
-      measure: order_count
-    filter: |
-      {{ Dimension('order_id__is_drink_order') }} = true
+        - {order_id: 1, count_food_items: 1, count_drink_items: 1, is_drink_order: true, is_food_order: true}
+        - {order_id: 2, count_food_items: 1, count_drink_items: 0, is_drink_order: false, is_food_order: true}
 
 saved_queries:
   - name: order_metrics

--- a/models/marts/products.yml
+++ b/models/marts/products.yml
@@ -1,26 +1,29 @@
-semantic_models:
-  #The name of the semantic model.
+models:
   - name: products
+    semantic_model:
+      enabled: true
     description: |
       Product dimension table. The grain of the table is one row per product.
-    #The name of the dbt model and schema
-    model: ref('products')
-    #Entities. These usually corespond to keys in the table.
-    entities:
-      - name: product
-        type: primary
-        expr: product_id
-    #Dimensions. Either categorical or time. These add additonal context to metrics. The typical querying pattern is Metric by Dimension.
-    dimensions:
+    columns:
+      - name: product_id
+        entity:
+          type: primary
+          name: product
       - name: product_name
-        type: categorical
+        dimension:
+          type: categorical
       - name: product_type
-        type: categorical
+        dimension:
+          type: categorical
       - name: product_description
-        type: categorical
+        dimension:
+          type: categorical
       - name: is_food_item
-        type: categorical
+        dimension:
+          type: categorical
       - name: is_drink_item
-        type: categorical
+        dimension:
+          type: categorical
       - name: product_price
-        type: categorical
+        dimension:
+          type: categorical

--- a/models/marts/supplies.yml
+++ b/models/marts/supplies.yml
@@ -1,24 +1,26 @@
-semantic_models:
-  #The name of the semantic model.
+models:
   - name: supplies
+    semantic_model:
+      enabled: true
     description: |
       Supplies dimension table. The grain of the table is one row per supply and product combination.
-    #The name of the dbt model and schema
-    model: ref('supplies')
-    #Entities. These usually corespond to keys in the table.
-    entities:
-      - name: supply
-        type: primary
-        expr: supply_uuid
-    #Dimensions. Either categorical or time. These add additonal context to metrics. The typical querying pattern is Metric by Dimension.
-    dimensions:
+    columns:
+      - name: supply_uuid
+        entity:
+          type: primary
+          name: supply
       - name: supply_id
-        type: categorical
+        dimension:
+          type: categorical
       - name: product_id
-        type: categorical
+        dimension:
+          type: categorical
       - name: supply_name
-        type: categorical
+        dimension:
+          type: categorical
       - name: supply_cost
-        type: categorical
+        dimension:
+          type: categorical
       - name: is_perishable_supply
-        type: categorical
+        dimension:
+          type: categorical

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -2,18 +2,20 @@ version: 2
 
 sources:
   - name: ecom
-    schema: raw
+    schema: "{{ var('raw_schema', 'raw') }}"
     description: E-commerce data for the Jaffle Shop
     tables:
       - name: raw_customers
         description: One record per person who has purchased one or more items
       - name: raw_orders
         description: One record per order (consisting of one or more order items)
-        loaded_at_field: ordered_at
+        config:
+          loaded_at_field: ordered_at
       - name: raw_items
         description: Items included in an order
       - name: raw_stores
-        loaded_at_field: opened_at
+        config:
+          loaded_at_field: opened_at
       - name: raw_products
         description: One record per SKU for items sold in stores
       - name: raw_supplies

--- a/models/staging/stg_order_items.yml
+++ b/models/staging/stg_order_items.yml
@@ -12,5 +12,6 @@ models:
         data_tests:
           - not_null
           - relationships:
-              to: ref('stg_orders')
-              field: order_id
+              arguments:
+                to: ref('stg_orders')
+                field: order_id

--- a/models/staging/stg_orders.yml
+++ b/models/staging/stg_orders.yml
@@ -3,7 +3,8 @@ models:
     description: Order data with basic cleaning and transformation applied, one row per order.
     data_tests:
       - dbt_utils.expression_is_true:
-          expression: "order_total - tax_paid = subtotal"
+          arguments:
+            expression: "order_total - tax_paid = subtotal"
     columns:
       - name: order_id
         description: The unique key for each order.

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,8 +1,11 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.1.1
-  - package: godatadriven/dbt_date
-    version: 0.10.0
-  - git: https://github.com/dbt-labs/dbt-audit-helper.git
-    revision: b8f3a3348ce0ff8afc3aa4b9ade2123b00772473
-sha1_hash: f2a73967505955af30d18f70489a423fd47cdf79
+- git: https://github.com/dbt-labs/dbt-audit-helper.git
+  name: audit_helper
+  revision: 71817f0a7fa3df9f63adb90db0cf28f7423f720b
+- package: godatadriven/dbt_date
+  name: dbt_date
+  version: 0.19.0
+- package: dbt-labs/dbt_utils
+  name: dbt_utils
+  version: 1.3.3
+sha1_hash: 71ace3bd36af71c8bc9b484e66bc38addb7262a1


### PR DESCRIPTION
## Summary
- migrate deprecated dbt YAML shapes for Fusion, including generic test arguments and source freshness config
- migrate legacy Semantic Layer YAML into model-owned Fusion-compatible metadata
- refresh package-lock.yml and ignore dbt_internal_packages/
- make raw seed/source schema configurable via raw_schema, defaulting to raw; local builds can override it to a writable schema

## Root cause
Fusion rejected the project before execution because the baseline YAML used deprecated generic-test argument placement, source loaded_at_field at the old level, and legacy semantic model/metric YAML. Local Snowflake builds also attempted to seed into the global raw schema, where the tester role lacks CREATE TABLE privileges.

## Validation
- ~/.local/bin/dbt --version -> dbt-fusion 2.0.0-preview.190
- ~/.local/bin/dbt build --vars '{"load_source_data": true, "raw_schema": "webbeard"}' -> 49 total, 49 success\n- DBT_PROFILES_DIR=$HOME/.dbt uvx --python 3.12 --from 'dbt-metricflow[dbt-snowflake]' mf validate-configs --skip-dw --show-all --verbose-issues -> ERRORS: 0, FUTURE_ERRORS: 0, WARNINGS: 0\n\nNote: dbt sl validate is still blocked in this local environment because dbt_cloud.yml does not contain the dbt-cloud project-id configured by this repo. The MetricFlow fallback is the docs-recommended local semantic validation path when not connected to dbt platform.