### PR TITLE
Fix typos in YAML docs and switch CI to ubuntu runners

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_snowflake:
     name: dbt Cloud Deploy Prod Snowflake
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -32,7 +32,7 @@ jobs:
 
   run_bigquery:
     name: dbt Cloud Deploy Prod BigQuery
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -56,7 +56,7 @@ jobs:
 
   run_postgres:
     name: dbt Cloud Deploy Prod Postgres
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483

--- a/.github/workflows/cd_staging.yml
+++ b/.github/workflows/cd_staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_snowflake:
     name: dbt Cloud Deploy Staging Snowflake
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -32,7 +32,7 @@ jobs:
 
   run_bigquery:
     name: dbt Cloud Deploy Staging BigQuery
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -56,7 +56,7 @@ jobs:
 
   run_postgres:
     name: dbt Cloud Deploy Staging Postgres
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run_snowflake:
     name: dbt Cloud PR CI Snowflake
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -32,7 +32,7 @@ jobs:
 
   run_bigquery:
     name: dbt Cloud PR CI BigQuery
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483
@@ -57,7 +57,7 @@ jobs:
 
   run_postgres:
     name: dbt Cloud PR CI Postgres
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       DBT_ACCOUNT_ID: 188483

--- a/models/marts/order_items.yml
+++ b/models/marts/order_items.yml
@@ -45,7 +45,7 @@ semantic_models:
     defaults:
       agg_time_dimension: ordered_at
     description: |
-      Items contatined in each order. The grain of the table is one row per order item.
+      Items contained in each order. The grain of the table is one row per order item.
     model: ref('order_items')
     entities:
       - name: order_item

--- a/models/marts/orders.yml
+++ b/models/marts/orders.yml
@@ -1,6 +1,6 @@
 models:
   - name: orders
-    description: Order overview data mart, offering key details for each order inlcluding if it's a customer's first order and a food vs. drink item breakdown. One row per order.
+    description: Order overview data mart, offering key details for each order including if it's a customer's first order and a food vs. drink item breakdown. One row per order.
     data_tests:
       - dbt_utils.expression_is_true:
           expression: "order_items_subtotal = subtotal"
@@ -122,7 +122,7 @@ semantic_models:
 
 metrics:
   - name: order_total
-    description: Sum of total order amonunt. Includes tax + revenue.
+    description: Sum of total order amount. Includes tax + revenue.
     type: simple
     label: Order Total
     type_params:

--- a/models/marts/products.yml
+++ b/models/marts/products.yml
@@ -5,7 +5,7 @@ semantic_models:
       Product dimension table. The grain of the table is one row per product.
     #The name of the dbt model and schema
     model: ref('products')
-    #Entities. These usually corespond to keys in the table.
+    #Entities. These usually correspond to keys in the table.
     entities:
       - name: product
         type: primary

--- a/models/marts/supplies.yml
+++ b/models/marts/supplies.yml
@@ -5,7 +5,7 @@ semantic_models:
       Supplies dimension table. The grain of the table is one row per supply and product combination.
     #The name of the dbt model and schema
     model: ref('supplies')
-    #Entities. These usually corespond to keys in the table.
+    #Entities. These usually correspond to keys in the table.
     entities:
       - name: supply
         type: primary


### PR DESCRIPTION
## Summary

1. Fix typos in model YAML description files:
   - "amonunt" -> "amount" (orders.yml)
   - "inlcluding" -> "including" (orders.yml)
   - "contatined" -> "contained" (order_items.yml)
   - "corespond" -> "correspond" (products.yml, supplies.yml)

2. Switch CI workflow runners from `macos-latest` to `ubuntu-latest` in ci.yml, cd_prod.yml, and cd_staging.yml — these jobs only run Python scripts to trigger dbt Cloud API calls and don't need macOS. Ubuntu runners are ~10x cheaper.

## Test plan

- [x] Changes are cosmetic/config only — no behavior change
- [x] Verified patterns exist before fixing