### PR TITLE
Fix supply cost unit test description

### DIFF
--- a/models/marts/order_items.yml
+++ b/models/marts/order_items.yml
@@ -13,7 +13,7 @@ models:
 
 unit_tests:
   - name: test_supply_costs_sum_correctly
-    description: "Test that the counts of drinks and food orders convert to booleans properly."
+    description: "Test that supply costs sum correctly for each order item."
     model: order_items
     given:
       - input: ref('stg_supplies')


### PR DESCRIPTION
Fixes #129

The description on test_supply_costs_sum_correctly in order_items.yml was copy-pasted from test_order_items_compute_to_bools_correctly (orders.yml). Updated it to describe what the test actually validates: that supply costs sum correctly per order item.